### PR TITLE
Pass FPM port number as argument for FpmCompiler via warmup-opcode

### DIFF
--- a/src/Compiler/FpmCompiler.php
+++ b/src/Compiler/FpmCompiler.php
@@ -10,11 +10,18 @@ use Symfony\Component\Process\ProcessBuilder;
 
 class FpmCompiler implements CompilerInterface
 {
+    private $port;
+
+    public function __construct(int $port = 9000)
+    {
+        $this->port = $port;
+    }
+
     public function compile(string $file)
     {
         require_once __DIR__.'/../../../../autoload.php';
 
-        $fastcgi = new \Adoy\FastCGI\Client('127.0.0.1', '9000');
+        $fastcgi = new \Adoy\FastCGI\Client('127.0.0.1', $this->port);
 
         $fastcgi->request([
             'GATEWAY_INTERFACE' => 'FastCGI/1.0',

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -18,7 +18,8 @@ class WarmupCommand extends BaseCommand
         $this
             ->setName('warmup-opcode')
             ->setDescription('Warmup the application\'s OpCode')
-            ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile');
+            ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile')
+            ->addArgument('port', null, 'FPM port number', 9000);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -55,7 +56,9 @@ class WarmupCommand extends BaseCommand
                 )
             )
         );
-        $compiler = new FpmCompiler();
+
+        $port = $input->getArgument('port');
+        $compiler = new FpmCompiler($port);
         foreach ($reader->getClassmap() as $file) {
             try {
                 $compiler->compile($file);


### PR DESCRIPTION
This allows to pass a port number as argument to the `warmup-opcode` command which calls `FpmCompiler` with a port number, instead using hardcoded port number `9000`.
The default port number did remain `9000` in case it's not passed.