### PR TITLE
Pass port number via option instead as argument for command

### DIFF
--- a/src/Compiler/FpmCompiler.php
+++ b/src/Compiler/FpmCompiler.php
@@ -12,7 +12,7 @@ class FpmCompiler implements CompilerInterface
 {
     private $port;
 
-    public function __construct(int $port = 9000)
+    public function __construct($port = 9000)
     {
         $this->port = $port;
     }

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -19,8 +19,8 @@ class WarmupCommand extends BaseCommand
         $this
             ->setName('warmup-opcode')
             ->setDescription('Warmup the application\'s OpCode')
-            ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile')
-            ->addOption('port', null, InputOption::VALUE_OPTIONAL, 'FPM port number', 9000);
+            ->addOption('port', null, InputOption::VALUE_OPTIONAL, 'FPM port number', 9000)
+            ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -19,7 +19,7 @@ class WarmupCommand extends BaseCommand
             ->setName('warmup-opcode')
             ->setDescription('Warmup the application\'s OpCode')
             ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile')
-            ->addOption('port', null, InputOption::VALUE_REQUIRED, '', 9000);
+            ->addOption('port', null, null, 'FPM port number', 9000);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -8,6 +8,7 @@ use Jderusse\Warmup\ClassmapReader\DirectoryReader;
 use Jderusse\Warmup\ClassmapReader\OptimizedReader;
 use Jderusse\Warmup\Compiler\FpmCompiler;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -19,7 +20,7 @@ class WarmupCommand extends BaseCommand
             ->setName('warmup-opcode')
             ->setDescription('Warmup the application\'s OpCode')
             ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile')
-            ->addOption('port', null, null, 'FPM port number', 9000);
+            ->addOption('port', null, InputOption::VALUE_OPTIONAL, 'FPM port number', 9000);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -19,7 +19,7 @@ class WarmupCommand extends BaseCommand
             ->setName('warmup-opcode')
             ->setDescription('Warmup the application\'s OpCode')
             ->addArgument('extra', InputArgument::IS_ARRAY, 'add extra path to compile')
-            ->addArgument('port', null, 'FPM port number', 9000);
+            ->addOption('port', null, InputOption::VALUE_REQUIRED, '', 9000);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -57,7 +57,7 @@ class WarmupCommand extends BaseCommand
             )
         );
 
-        $port = $input->getArgument('port');
+        $port = $input->getOption('port');
         $compiler = new FpmCompiler($port);
         foreach ($reader->getClassmap() as $file) {
             try {


### PR DESCRIPTION
This simply changes how port number gets passed to command, using option instead argument.